### PR TITLE
Add teardown_module as a finalizer

### DIFF
--- a/tests/test_extract_metadata.py
+++ b/tests/test_extract_metadata.py
@@ -26,8 +26,8 @@ from metabase import extract_metadata
 #   Module-level fixtures
 # #############################################################################
 
-@pytest.fixture()
-def setup_module(scope='module'):
+@pytest.fixture(scope='module')
+def setup_module(request):
     """
     Setup module-level fixtures.
     """
@@ -61,6 +61,14 @@ def setup_module(scope='module'):
     mock_params.metabase_connection_string = conn_str
     mock_params.data_connection_string = conn_str
 
+    def teardown_module():
+        """
+        Delete the temporary database.
+        """
+        postgresql.stop()
+
+    request.addfinalizer(teardown_module)
+
     return_db = collections.namedtuple(
         'db',
         ['postgresql', 'engine', 'mock_params']
@@ -71,14 +79,6 @@ def setup_module(scope='module'):
         engine=engine,
         mock_params=mock_params
     )
-
-
-@pytest.fixture()
-def teardown_module(setup_module):
-    """
-    Delete the temporary database.
-    """
-    setup_module.postgresql.stop()
 
 
 # #############################################################################


### PR DESCRIPTION
> @shen-h These changes look good. Take a look at the commit I added to remove the global variables from the tests since you think they might be causing problems. If I'm [understanding correctly](https://docs.pytest.org/en/latest/fixture.html#scope-sharing-a-fixture-instance-across-tests-in-a-class-module-or-session), using `scope=module` should make that fixture only run one.


@mollyrossow Thanks for refactoring the module setup. I've rerun the updated tests more than 20 times and none of them report the server shutdown error, while the probability of running into that error in the previous version of the tests is about 1 out of 10.

In this commit, I just added `teardown_module` as a finalizer within `setup_module` to make it similar to the structure of function-level setups. 

Regarding the scope, I followed that [blogpost](http://pythontesting.net/framework/pytest/pytest-fixtures-easy-example/)'s suggestion of using the default setting at first, which is at the function-level. But make it work on module-level is definitely what we want sooner or later. Thanks for bringing it up.