### PR TITLE
Add serial PKs to column-info-related tables

### DIFF
--- a/alembic/versions/0fbe9f4e9934_create_tables.py
+++ b/alembic/versions/0fbe9f4e9934_create_tables.py
@@ -190,6 +190,7 @@ def upgrade():
 
     op.create_table(
         'column_info',
+        sa.Column('column_info_id', sa.Integer, primary_key=True),
         sa.Column('data_table_id', sa.Integer),
         sa.Column('column_name', sa.Text),
         sa.Column('data_type', sa.Text),
@@ -202,6 +203,7 @@ def upgrade():
 
     op.create_table(
         'numeric_column',
+        sa.Column('numeric_column_id', sa.Integer, primary_key=True),
         sa.Column('data_table_id', sa.Integer),
         sa.Column('column_name', sa.Text),
         sa.Column('minimum', sa.Integer),
@@ -217,6 +219,7 @@ def upgrade():
 
     op.create_table(
         'text_column',
+        sa.Column('text_column_id', sa.Integer, primary_key=True),
         sa.Column('data_table_id', sa.Integer),
         sa.Column('column_name', sa.Text),
         sa.Column('max_length', sa.Integer),
@@ -231,6 +234,7 @@ def upgrade():
 
     op.create_table(
         'date_column',
+        sa.Column('date_column_id', sa.Integer, primary_key=True),
         sa.Column('data_table_id', sa.Integer),
         sa.Column('column_name', sa.Text),
         sa.Column('max_date', sa.Date),
@@ -244,6 +248,7 @@ def upgrade():
 
     op.create_table(
         'code_frequency',
+        sa.Column('code_frequency_id', sa.Integer, primary_key=True),
         sa.Column('data_table_id', sa.Integer),
         sa.Column('column_name', sa.Text),
         sa.Column('code', sa.Text),
@@ -524,96 +529,6 @@ def upgrade():
         referent_schema=SCHEMA_NAME,
     )
 
-    # Create keys on column_info.
-    op.create_primary_key(
-        'column_info_pk',
-        'column_info',
-        ['data_table_id', 'column_name'],
-        schema=SCHEMA_NAME,
-    )
-
-    op.create_foreign_key(
-        'column_info_data_table_fk',
-        'column_info',
-        'data_table',
-        ['data_table_id'],
-        ['data_table_id'],
-        source_schema=SCHEMA_NAME,
-        referent_schema=SCHEMA_NAME,
-    )
-
-    # Create keys on numeric_column.
-    op.create_primary_key(
-        'numeric_column_pk',
-        'numeric_column',
-        ['data_table_id', 'column_name'],
-        schema=SCHEMA_NAME,
-    )
-
-    op.create_foreign_key(
-        'numeric_column_column_info_fk',
-        'numeric_column',
-        'column_info',
-        ['data_table_id', 'column_name'],
-        ['data_table_id', 'column_name'],
-        source_schema=SCHEMA_NAME,
-        referent_schema=SCHEMA_NAME,
-    )
-
-    # Create keys on text_columns.
-    op.create_primary_key(
-        'text_column_pk',
-        'text_column',
-        ['data_table_id', 'column_name'],
-        schema=SCHEMA_NAME
-    )
-
-    op.create_foreign_key(
-        'text_column_column_info_fk',
-        'text_column',
-        'column_info',
-        ['data_table_id', 'column_name'],
-        ['data_table_id', 'column_name'],
-        source_schema=SCHEMA_NAME,
-        referent_schema=SCHEMA_NAME,
-    )
-
-    # Create keys on date_columns.
-    op.create_primary_key(
-        'date_column_pk',
-        'date_column',
-        ['data_table_id', 'column_name'],
-        schema=SCHEMA_NAME
-    )
-
-    op.create_foreign_key(
-        'date_column_column_info_fk',
-        'date_column',
-        'column_info',
-        ['data_table_id', 'column_name'],
-        ['data_table_id', 'column_name'],
-        source_schema=SCHEMA_NAME,
-        referent_schema=SCHEMA_NAME,
-    )
-
-    # Create keys on code_frequency.
-    op.create_primary_key(
-        'code_frequency_pk',
-        'code_frequency',
-        ['data_table_id', 'column_name', 'code'],
-        schema=SCHEMA_NAME
-    )
-
-    op.create_foreign_key(
-        'code_frequency_column_info_fk',
-        'code_frequency',
-        'column_info',
-        ['data_table_id', 'column_name'],
-        ['data_table_id', 'column_name'],
-        source_schema=SCHEMA_NAME,
-        referent_schema=SCHEMA_NAME,
-    )
-
     # Create keys on data_dictionary.
     op.create_primary_key(
         'data_dictionary_pk',
@@ -789,36 +704,6 @@ def downgrade():
     op.drop_constraint(
         'etl_output_data_table_fk',
         'etl_output',
-        schema=SCHEMA_NAME,
-    )
-
-    op.drop_constraint(
-        'column_info_data_table_fk',
-        'column_info',
-        schema=SCHEMA_NAME,
-    )
-
-    op.drop_constraint(
-        'numeric_column_column_info_fk',
-        'numeric_column',
-        schema=SCHEMA_NAME,
-    )
-
-    op.drop_constraint(
-        'text_column_column_info_fk',
-        'text_column',
-        schema=SCHEMA_NAME
-    )
-
-    op.drop_constraint(
-        'date_column_column_info_fk',
-        'date_column',
-        schema=SCHEMA_NAME,
-    )
-
-    op.drop_constraint(
-        'code_frequency_column_info_fk',
-        'code_frequency',
         schema=SCHEMA_NAME,
     )
 


### PR DESCRIPTION
I followed the naming convention of some other tables that have serial IDs, and named the new serial IDs as `<table_name>_id`.